### PR TITLE
Data Re-Fetching in React

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,19 +92,16 @@ const App = () => {
   );
 
   React.useEffect(() => {
+    //  if `searchTerm is not present
+    // e.g. null, epmty string, undefined
+    // do nothing
+    // more generalized condition than searchTerm === ''
+
+    if (searchTerm === '') return;
+
     dispatchStories({ type: 'STORIES_FETCH_INIT' });
 
-    //   getAsyncStories()
-    //     .then((result) => {
-    //       dispatchStories({
-    //         type: STORIES_FETCH_SUCCESS,
-    //         payload: result.data.stories,
-    //       });
-    //     })
-    //     .catch(() => dispatchStories({ type: STORIES_FETCH_FAILURE }));
-    // }, []);
-
-    fetch(`${API_ENDPOINT}react`) // Use native browser's fetch API to make request
+    fetch(`${API_ENDPOINT}${searchTerm}`) // Use native browser's fetch API to make request
       .then((response) => response.json()) // Translate response to JSON
       .then((result) => {
         dispatchStories({
@@ -115,7 +112,7 @@ const App = () => {
       .catch(() =>
         dispatchStories({ type: 'STORIES_FETCH_FAILURE' })
       );
-  }, []);
+  }, [searchTerm]);
 
   const handleRemoveStory = (item) => {
     dispatchStories({
@@ -152,10 +149,7 @@ const App = () => {
       {stories.isLoading ? (
         <p>Loading ...</p>
       ) : (
-        <List
-          list={searchedStories}
-          onRemoveItem={handleRemoveStory}
-        />
+        <List list={stories.data} onRemoveItem={handleRemoveStory} />
       )}
     </div>
   );


### PR DESCRIPTION
In this section, we change the client-side search to a server-side search. While a client-side search only filtered the stories that were available on the client (after the initial data fetching), a server-side search allows us to get data from the remote API based on the search term. Instead of filtering a predefined list of stories on the client, the searchTerm is used to fetch a server-side filtered list. The server-side search happens not only for the initial data fetching, but also for data fetching if the searchTerm changes. The search feature is fully server-side now.