### PR TITLE
Explicit Data Fetching with React

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,10 @@ const App = () => {
     'React'
   );
 
+  const [url, setUrl] = React.useState(
+    `${API_ENDPOINT}${searchTerm}`
+  );
+
   const [stories, dispatchStories] = React.useReducer(
     storiesReducer,
     { data: [], isLoading: false, isError: false }
@@ -72,11 +76,12 @@ const App = () => {
     // do nothing
     // more generalized condition than searchTerm === ''
 
-    if (searchTerm === '') return;
+    // if (searchTerm === '') return;
 
     dispatchStories({ type: 'STORIES_FETCH_INIT' });
 
-    fetch(`${API_ENDPOINT}${searchTerm}`) // Use native browser's fetch API to make request
+    // fetch(`${API_ENDPOINT}${searchTerm}`) // Use native browser's fetch API to make request
+    fetch(url)
       .then((response) => response.json()) // Translate response to JSON
       .then((result) => {
         dispatchStories({
@@ -87,8 +92,8 @@ const App = () => {
       .catch(() =>
         dispatchStories({ type: 'STORIES_FETCH_FAILURE' })
       );
-  }, [searchTerm]); // React's useCallback Hook creates a memoized function every time this dependency array changes
-
+    // }, [searchTerm]); // React's useCallback Hook creates a memoized function every time this dependency array changes
+  }, [url]);
   React.useEffect(() => {
     handleFetchStories(); // Invoke handleFetchStories function in useEffect Hook
   }, [handleFetchStories]);
@@ -100,8 +105,12 @@ const App = () => {
     });
   };
 
-  const handleSearch = (event) => {
+  const handleSearchInput = (event) => {
     setSearchTerm(event.target.value);
+  };
+
+  const handleSearchSubmit = () => {
+    setUrl(`${API_ENDPOINT}${searchTerm}`);
   };
 
   const searchedStories = stories.data.filter((story) =>
@@ -116,10 +125,18 @@ const App = () => {
         id="search"
         value={searchTerm}
         isFocused
-        onInputChange={handleSearch}
+        onInputChange={handleSearchInput}
       >
         <strong>Search:</strong>
       </InputWithLabel>
+
+      <button
+        type="button"
+        disabled={!searchTerm}
+        onClick={handleSearchSubmit}
+      >
+        Submit
+      </button>
 
       <hr />
 


### PR DESCRIPTION
Before the searchTerm was used for two cases: updating the input field’s state and activating the side-effect for fetching data. Now it’s only used for the former. A second state called url got introduced for triggering the side-effect that fetches the data which only happens when a user clicks the confirmation button. As long as the button is not clicked, the search term can change but isn’t executed as API request.